### PR TITLE
Fix spelling: Personnalité / Personell => Personality / Personal

### DIFF
--- a/templates/index.tmpl
+++ b/templates/index.tmpl
@@ -78,7 +78,7 @@
                     My name is Paul Lhussiez and I'm a 23 years old passionate developer. People usually call me Depado. It's my nickname quite everywhere on internet.
                 </p>
                 <p>
-                    I currently live in Paris and I'm working for Leboncoin's Lab. In this website you'll find some information about me, such as my projects, experience, skills… If you wish to learn more about my personnality, you can head to <a href="/about">this page</a>.
+                    I currently live in Paris and I'm working for Leboncoin's Lab. In this website you'll find some information about me, such as my projects, experience, skills… If you wish to learn more about my personality, you can head to <a href="/about">this page</a>.
                 </p>
                 <p>
                     I'm mostly interested in the Go programming language for the backend side. I'm polyvalent, I can administrate servers, automate deployments, and I enjoy working with a cloud provider such as Outscale and Scaleway. I love APIs ! ♥

--- a/templates/projects.tmpl
+++ b/templates/projects.tmpl
@@ -3,7 +3,7 @@
     <div class="ui container">
         <h3 class="ui header">Projects</h3>
         <p>
-            In this section I'll present to you some of my personnal projects. The data displayed here are automatically fetched using the API of my <a href="https://monit.depado.eu" target="_blank">monitoring service</a>. If you wish to get more information
+            In this section I'll present to you some of my personal projects. The data displayed here are automatically fetched using the API of my <a href="https://monit.depado.eu" target="_blank">monitoring service</a>. If you wish to get more information
             on these projects you can either check the website, the github repository or the monitoring service which holds more data (commit history, build history, response time…)
         </p>
         <p>


### PR DESCRIPTION
[Personality](http://www.dictionary.com/browse/personality) and [personal](http://www.dictionary.com/browse/personal) are written with a single "n" in English, whilst in French they're written with two "n"s.  
  
This PR fixes the typo :)